### PR TITLE
EUT-202 - Adds command line option for reports.

### DIFF
--- a/adagucserverEC/adagucserver.cpp
+++ b/adagucserverEC/adagucserver.cpp
@@ -168,7 +168,8 @@ int _main(int argc, char **argv){
           { "file", required_argument, 0, 0 },
           { "inspiredatasetcsw", required_argument, 0, 0 },
           { "datasetpath", required_argument, 0, 0 },
-          { "test", no_argument, 0, 0 }
+          { "test", no_argument, 0, 0 },
+          { "report", optional_argument, 0, 0 }
       };
 
       opt = getopt_long(argc, argv, "", long_options, &opt_idx);
@@ -219,6 +220,12 @@ int _main(int argc, char **argv){
               inspireDatasetCSW = optarg;
           if(strncmp(long_options[opt_idx].name, "datasetpath", 11) == 0)
               datasetPath = optarg;
+          if(strncmp(long_options[opt_idx].name, "report", 6) == 0) {
+              if(optarg) CReporter::getInstance()->filename(optarg);
+              else if (getenv("ADAGUC_CHECKER_FILE"))
+                  CReporter::getInstance()->filename(getenv("ADAGUC_CHECKER_FILE"));
+              else CReporter::getInstance()->filename(REPORT_DEFAULT_FILE);
+          }
       }
   }
 
@@ -310,13 +317,7 @@ int main(int argc, char **argv){
   int status = _main(argc,argv);
 
   // Print the check report formatted as JSON.
-  const char *  ADAGUC_CHECKER_DIR =getenv("ADAGUC_CHECKER_DIR");
-  if (ADAGUC_CHECKER_DIR != NULL) {
-    CReportWriter::writeJSONReportToFile(CT::string(ADAGUC_CHECKER_DIR) + "/checker_report.txt");
-  } else {
-    // Default config used by tests.
-    CReportWriter::writeJSONReportToFile("./checker_report.txt");
-  }
+  CReportWriter::writeJSONReportToFile();
 
   CCachedDirReader::free();
   

--- a/hclasses/CReportWriter.cpp
+++ b/hclasses/CReportWriter.cpp
@@ -10,13 +10,14 @@ using json = nlohmann::json;
 
 namespace CReportWriter {
 
-  bool writeJSONReportToFile(const CT::string reportFilename) {
+  bool writeJSONReportToFile() {
     json report;
     CReporter *cReporter = CReporter::getInstance();
 
+    if (!cReporter->filename()) return false;
     report["messages"] = json(cReporter->getMessageList());
 
-    std::ofstream reportfile(reportFilename.c_str());
+    std::ofstream reportfile(cReporter->filename().c_str());
     if(!reportfile) {
       return false;
     }

--- a/hclasses/CReportWriter.h
+++ b/hclasses/CReportWriter.h
@@ -24,10 +24,9 @@ namespace CReportWriter {
    *         "Warning message 2."
    *     ]
    *
-   * @param reportFilename The filename (including path) of the resulting file.
    * @returns True if it was possible to write the report to a file.
    */
-  bool writeJSONReportToFile(const CT::string reportFilename);
+  bool writeJSONReportToFile();
 };
 
 #endif //CREPORT_WRITER_JSON_H

--- a/hclasses/CReporter.cpp
+++ b/hclasses/CReporter.cpp
@@ -10,7 +10,8 @@ using Categories = CReportMessage::Categories;
 
 CReporter *CReporter::instance = NULL;
 
-CReporter::CReporter(bool report_and_log) : messageList(), writelog(report_and_log) {
+CReporter::CReporter(bool report_and_log)
+    : messageList(), writelog(report_and_log), _filename() {
     // Empty at this point
 }
 
@@ -59,4 +60,14 @@ void CReporter::writeMessageToLog(const CT::string message, CReportMessage::Seve
 
 const std::list<CReportMessage> CReporter::getMessageList() const {
   return messageList;
+}
+
+void CReporter::filename(const CT::string filename)
+{
+    this->_filename = filename;
+}
+
+CT::string CReporter::filename() const
+{
+    return this->_filename;
 }

--- a/hclasses/CReporter.h
+++ b/hclasses/CReporter.h
@@ -11,6 +11,8 @@
 // Set this to false if you don't want report messages in the log file also.
 #define REPORT_AND_LOG true 
 
+#define REPORT_DEFAULT_FILE "./checker_report.txt"
+
 #define CREPORT_INFO(message, category, documentationLink) CReporter::getInstance()->addMessage(message, CReportMessage::Severities::INFO, category, documentationLink, __FILE__, __LINE__, className)
 #define CREPORT_INFO_NODOC(message, category) CReporter::getInstance()->addMessage(message, CReportMessage::Severities::INFO, category, "", __FILE__, __LINE__, className)
 #define CREPORT_WARN(message, category, documentationLink) CReporter::getInstance()->addMessage(message, CReportMessage::Severities::WARNING, category, documentationLink, __FILE__, __LINE__, className)
@@ -25,6 +27,7 @@ private:
   std::list<CReportMessage> messageList;
   void writeMessageToLog(const CT::string message, CReportMessage::Severities severity, const char* file, int line, const char* className) const;
   bool writelog = false;
+  CT::string _filename;
 
 protected:
   CReporter(bool report_and_log=false);
@@ -33,6 +36,8 @@ public:
   static CReporter *getInstance();
   const std::list<CReportMessage> getMessageList() const;
   void addMessage(const CT::string message, CReportMessage::Severities severity, CReportMessage::Categories category, CT::string documentationLink, const char* file="", int line=-1, const char* className="");
+  void filename(const CT::string filename);
+  CT::string filename() const;
 };
 
 

--- a/tests/AdagucTests/TestWMS.py
+++ b/tests/AdagucTests/TestWMS.py
@@ -76,6 +76,20 @@ class TestWMS(unittest.TestCase):
         self.checkReport(reportFilename="checker_report.txt",
                          expectedReportFilename="checker_report_WMSGetMap_testdatanc.txt")
 
+    def test_WMSGetMap_Report_env(self):
+        AdagucTestTools().cleanTempDir()
+        filename="test_WMSGetMap_Report_env"
+        reportfilename="./env_checker_report.txt"
+        self.env['ADAGUC_CHECKER_FILE']=reportfilename
+        status,data,headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=30,-30,75,30&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&",
+                                                                env = self.env, args=["--report"])
+        AdagucTestTools().writetofile(self.testresultspath + filename,data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(os.path.exists(reportfilename))
+        self.env.pop('ADAGUC_CHECKER_FILE', None)
+        if(os.path.exists(reportfilename)):
+            os.remove(reportfilename)
+
     def test_WMSGetMap_testdatanc_customprojectionstring(self):
         AdagucTestTools().cleanTempDir()
         


### PR DESCRIPTION
- Use --report to write report file in default location.
- Use --report=filename to write report in filename
- When neither is given and ADAGUC_CHECKER_FILE environment variable is
set, write report file to the value of ADAGUC_CHECKER_FILE environment
variable.
- When neither is given and ADAGUC_CHECKER_FILE is not set, no report is
written.

TestWMS.test_WMSGetMap_testdatanc tests the first option.
TestWMS.test_WMSGetMap_Report_nounits tests the second option.
TestWMS.test_WMSGetCapabilities_testdatanc tests the last option.

TODO: write a test for the third (set by environment) option.